### PR TITLE
Update Code of Conduct and Security Policy

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,10 @@
+# Microsoft Open Source Code of Conduct
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+
+Resources:
+
+- [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/)
+- [Microsoft Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
+- Contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with questions or concerns
+- Employees can reach out at [aka.ms/opensource/moderation-support](https://aka.ms/opensource/moderation-support)

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,12 +1,41 @@
-# Security Vulnerabilities
+<!-- BEGIN MICROSOFT SECURITY.MD V0.0.9 BLOCK -->
 
-Security issues are treated very seriously and will, by default,
-takes precedence over other considerations including usability, performance,
-etc...  Best effort will be used to mitigate side effects of a security
-change, but PowerShell must be secure by default.
+## Security
 
-## Reporting a security vulnerability
+Microsoft takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations, which include [Microsoft](https://github.com/Microsoft), [Azure](https://github.com/Azure), [DotNet](https://github.com/dotnet), [AspNet](https://github.com/aspnet), [Xamarin](https://github.com/xamarin) and [PowerShell](https://github.com/PowerShell).
 
-If you believe that there is a security vulnerability in PowerShell,
-it **must** be reported to [secure@microsoft.com](https://technet.microsoft.com/security/ff852094.aspx) to allow for [Coordinated Vulnerability Disclosure](https://technet.microsoft.com/security/dn467923).
-**Only** file an issue, if [secure@microsoft.com](https://www.microsoft.com/en-us/msrc/faqs-report-an-issue?rtc=1) has confirmed filing an issue is appropriate.
+If you believe you have found a security vulnerability in any Microsoft-owned repository that meets [Microsoft's definition of a security vulnerability](https://aka.ms/security.md/definition), please report it to us as described below.
+
+## Reporting Security Issues
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, please report them to the Microsoft Security Response Center (MSRC) at [https://msrc.microsoft.com/create-report](https://aka.ms/security.md/msrc/create-report).
+
+If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the [Microsoft Security Response Center PGP Key page](https://aka.ms/security.md/msrc/pgp).
+
+You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://www.microsoft.com/msrc). 
+
+Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
+
+  * Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
+  * Full paths of source file(s) related to the manifestation of the issue
+  * The location of the affected source code (tag/branch/commit or direct URL)
+  * Any special configuration required to reproduce the issue
+  * Step-by-step instructions to reproduce the issue
+  * Proof-of-concept or exploit code (if possible)
+  * Impact of the issue, including how an attacker might exploit the issue
+
+This information will help us triage your report more quickly.
+
+If you are reporting for a bug bounty, more complete reports can contribute to a higher bounty award. Please visit our [Microsoft Bug Bounty Program](https://aka.ms/security.md/msrc/bounty) page for more details about our active programs.
+
+## Preferred Languages
+
+We prefer all communications to be in English.
+
+## Policy
+
+Microsoft follows the principle of [Coordinated Vulnerability Disclosure](https://aka.ms/security.md/cvd).
+
+<!-- END MICROSOFT SECURITY.MD BLOCK -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,8 +1,0 @@
-# Code of Conduct
-
-This project has adopted the [Microsoft Open Source Code of Conduct][conduct-code].
-For more information see the [Code of Conduct FAQ][conduct-FAQ] or contact [opencode@microsoft.com][conduct-email] with any additional questions or comments.
-
-[conduct-code]: https://opensource.microsoft.com/codeofconduct/
-[conduct-FAQ]: https://opensource.microsoft.com/codeofconduct/faq/
-[conduct-email]: mailto:opencode@microsoft.com

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ConsoleGuiTools - `Out-ConsoleGridView` and `Show-ObjectTree`
 
-This repo contains the `Out-ConsoleGridView` 
+This repo contains the `Out-ConsoleGridView`
 PowerShell Cmdlet providing console-based GUI experiences based on
 [Terminal.Gui (gui.cs)](https://github.com/gui-cs/Terminal.Gui).
 
@@ -94,7 +94,7 @@ Get-Process -ComputerName "Server01" | ocgv -Title "Processes - Server01"
 
 This command displays the processes that are running on the Server01 computer in a grid view window.
 
-The command uses `ocgv`, which is the built-in alias for the **Out-ConsoleGridView** cmdlet, it uses the *Title* parameter to specify the window title.
+The command uses `ocgv`, which is the built-in alias for the **Out-ConsoleGridView** cmdlet, it uses the _Title_ parameter to specify the window title.
 
 ### Example 6: Define a function to kill processes using a graphical chooser
 
@@ -102,9 +102,10 @@ The command uses `ocgv`, which is the built-in alias for the **Out-ConsoleGridVi
 function killp { Get-Process | Out-ConsoleGridView -OutputMode Single -Filter $args[0] | Stop-Process -Id {$_.Id} }
 killp note
 ```
+
 This example shows defining a function named `killp` that shows a grid view of all running processes and allows the user to select one to kill it.
 
-The example uses the `-Filter` paramter to filter for all proceses with a name that includes `note` (thus highlighting `Notepad` if it were running. Selecting an item in the grid view and pressing `ENTER` will kill that process. 
+The example uses the `-Filter` paramter to filter for all proceses with a name that includes `note` (thus highlighting `Notepad` if it were running. Selecting an item in the grid view and pressing `ENTER` will kill that process.
 
 ### Example 7: Pass multiple items through Out-ConsoleGridView
 
@@ -115,8 +116,8 @@ Get-Process | Out-ConsoleGridView -PassThru | Export-Csv -Path .\ProcessLog.csv
 This command lets you select multiple processes from the **Out-ConsoleGridView** window.
 The processes that you select are passed to the **Export-Csv** command and written to the ProcessLog.csv file.
 
-The command uses the *PassThru* parameter of **Out-ConsoleGridView**, which lets you send multiple items down the pipeline.
-The *PassThru* parameter is equivalent to using the Multiple value of the *OutputMode* parameter.
+The command uses the _PassThru_ parameter of **Out-ConsoleGridView**, which lets you send multiple items down the pipeline.
+The _PassThru_ parameter is equivalent to using the Multiple value of the _OutputMode_ parameter.
 
 ### Example 8: Use F7 as "Show Command History"
 
@@ -126,7 +127,7 @@ Press `F7` to see the history for the current PowerShell instance
 
 Press `Shift-F7` to see the history for all PowerShell instances.
 
-Whatever you select within `Out-ConsoleGridView` will be inserted on your command line. 
+Whatever you select within `Out-ConsoleGridView` will be inserted on your command line.
 
 Whatever was typed on the command line prior to hitting `F7` or `Shift-F7` will be used as a filter.
 
@@ -214,27 +215,26 @@ to learn more.
 
 `ConsoleGuiTools` consists of 2 .NET Projects:
 
-- ConsoleGuiTools - Cmdlet implementation for Out-ConsoleGridView
-- OutGridView.Models - Contains data contracts between the GUI & Cmdlet
+* ConsoleGuiTools - Cmdlet implementation for Out-ConsoleGridView
+* OutGridView.Models - Contains data contracts between the GUI & Cmdlet
 
 _Note:_ Previously, this repo included `Microsoft.PowerShell.GraphicalTools` which included the Avalonia-based `Out-GridView` (implemented in `.\Microsoft.PowerShell.GraphicalTools` and `.\OutGridView.Gui`). These components have been deprecated (see note above).
 
 ## Maintainers
 
-- [Andy Jordan](https://andyleejordan.com) - [@andyleejordan](https://github.com/andyleejordan)
+* [Andy Jordan](https://andyleejordan.com) - [@andyleejordan](https://github.com/andyleejordan)
+* [Tig Kindel](https://www.kindel.com) - [@tig](https://github.com/tig)
 
 Originally authored by [Tyler Leonhardt](http://twitter.com/tylerleonhardt).
 
 ## License
 
-This project is [licensed under the MIT License](LICENSE).
+This project is [licensed under the MIT License](LICENSE.txt).
 
-## [Code of Conduct][conduct-md]
+## Code of Conduct
 
-This project has adopted the [Microsoft Open Source Code of Conduct][conduct-code].
-For more information see the [Code of Conduct FAQ][conduct-FAQ] or contact [opencode@microsoft.com][conduct-email] with any additional questions or comments.
+Please see our [Code of Conduct](.github/CODE_OF_CONDUCT.md) before participating in this project.
 
-[conduct-code]: https://opensource.microsoft.com/codeofconduct/
-[conduct-FAQ]: https://opensource.microsoft.com/codeofconduct/faq/
-[conduct-email]: mailto:opencode@microsoft.com
-[conduct-md]: https://github.com/PowerShell/ConsoleGuiTools/tree/master/CODE_OF_CONDUCT.md
+## Security Policy
+
+For any security issues, please see our [Security Policy](.github/SECURITY.md).


### PR DESCRIPTION
Updates the readme, code of conduct and security policy per OSPO request.

Also auto-fix Markdown issues and list Tig as a maintainer.